### PR TITLE
fix: fix issue of cases where prevCondition is a subscriber

### DIFF
--- a/lib/cluster/ClusterSubscriber.ts
+++ b/lib/cluster/ClusterSubscriber.ts
@@ -140,14 +140,10 @@ export default class ClusterSubscriber {
     // Re-subscribe previous channels
     const previousChannels = { subscribe: [], psubscribe: [], ssubscribe: [] };
     if (lastActiveSubscriber) {
-      const condition =
-        lastActiveSubscriber.condition || lastActiveSubscriber.prevCondition;
-      if (condition && condition.subscriber) {
-        previousChannels.subscribe = condition.subscriber.channels("subscribe");
-        previousChannels.psubscribe =
-          condition.subscriber.channels("psubscribe");
-        previousChannels.ssubscribe =
-          condition.subscriber.channels("ssubscribe");
+      const subscriber = lastActiveSubscriber.condition?.subscriber || lastActiveSubscriber.prevCondition?.subscriber;
+      if (subscriber) {
+        previousChannels.subscribe = subscriber.channels("subscribe");
+        previousChannels.psubscribe = subscriber.channels("psubscribe");
       }
     }
     if (


### PR DESCRIPTION
The current logic does an or operation between condition and prevCondition.

In condition the value of subscriber could be false and in prevCondition it could be a subscription set.

The change addresses this by picking the first non false subscriber.